### PR TITLE
Add 4 fixes for Master of Fire, Encourage, Book of Power and Stack splitting

### DIFF
--- a/BookOfPowerLevelUp.cpp
+++ b/BookOfPowerLevelUp.cpp
@@ -1,0 +1,28 @@
+#include "pch.h"
+// Fix: After level up hero max mana calculation does not take into account knowledge bonus from book of power.
+
+void BookOfPowerLevelUp();
+
+void BookOfPowerLevelUp_init(pugi::xml_document& doc) {
+    assembly_patches.push_back({ PATCH_HOOK, 0x00B5A5F2, 5, BookOfPowerLevelUp, 0, 0, 0, 0 });
+    assembly_patches.push_back({ PATCH_HOOK, 0x00B5A5D7, 5, BookOfPowerLevelUp, 0, 0, 0, 0 });
+}
+
+int BookOfPowerLevelUp_game_update = 0x0050C020;
+int BookOfPowerLevelUp_game_return = 0x00B5A5F7;
+__declspec(naked) void BookOfPowerLevelUp() {
+    __asm
+    {
+        mov eax, dword ptr ss : [ebp + 0x1C]
+        lea ecx, dword ptr ss : [ebp + 0x1C]
+        call dword ptr ds : [eax + 0x1C]
+        push eax
+        mov eax, dword ptr ss : [ebp + 0x1C]
+        lea ecx, dword ptr ss : [ebp + 0x1C]
+        call dword ptr[eax + 0x130]
+        mov[ebp + 0x15C], eax
+        mov ecx, [ebp]
+        call[BookOfPowerLevelUp_game_update]
+        jmp[BookOfPowerLevelUp_game_return]
+    }
+}

--- a/EncourageFix.cpp
+++ b/EncourageFix.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+// Fix: Encourage affected by resistance
+
+void EncourageFix_init(pugi::xml_document& doc) {
+	assembly_patches.push_back({ PATCH_BYTE, 0x00A34158, 1, nullptr, 1, 0, 0, 0 });
+}

--- a/H5_DLL.vcxproj
+++ b/H5_DLL.vcxproj
@@ -194,9 +194,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AgilityFix.cpp" />
+    <ClCompile Include="BookOfPowerLevelUp.cpp" />
     <ClCompile Include="CombatAIFix.cpp" />
+    <ClCompile Include="MasterOfFireFix.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="EliteCastersFix.cpp" />
+    <ClCompile Include="EncourageFix.cpp" />
     <ClCompile Include="globals.cpp" />
     <ClCompile Include="ArcaneRenewalFix.cpp" />
     <ClCompile Include="EmpoweredArmageddonFixes.cpp" />
@@ -205,6 +208,7 @@
     <ClCompile Include="pugixml.cpp" />
     <ClCompile Include="RuneOfTheDragonForm.cpp" />
     <ClCompile Include="SnareFix.cpp" />
+    <ClCompile Include="OneStackSplit.cpp" />
     <ClCompile Include="utility_functions.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/H5_DLL.vcxproj.filters
+++ b/H5_DLL.vcxproj.filters
@@ -89,6 +89,18 @@
     <ClCompile Include="pugixml.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="OneStackSplit.cpp">
+      <Filter>Source Files\patches</Filter>
+    </ClCompile>
+    <ClCompile Include="BookOfPowerLevelUp.cpp">
+      <Filter>Source Files\patches\ToE_fixes</Filter>
+    </ClCompile>
+    <ClCompile Include="MasterOfFireFix.cpp">
+      <Filter>Source Files\patches\ToE_fixes</Filter>
+    </ClCompile>
+    <ClCompile Include="EncourageFix.cpp">
+      <Filter>Source Files\patches\ToE_fixes</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="x86\MinHook.dll">

--- a/MasterOfFireFix.cpp
+++ b/MasterOfFireFix.cpp
@@ -1,0 +1,43 @@
+#include "pch.h"
+// Fix: Master of Fire always substracting half defense from the moment of impact instead of half of the current creature defense
+
+void MasterOfFireFix();
+
+void MasterOfFireFix_init(pugi::xml_document& doc) {
+        assembly_patches.push_back({ PATCH_BYTE, 0x00989BB6, 1, nullptr, 9, 0, 0, 0 }); // disable bugged Master of Fire effect
+        assembly_patches.push_back({ PATCH_HOOK, 0x008A25F4, 13, MasterOfFireFix, 0, 0, 0, 0 }); // new Master of Fire code
+}
+
+__declspec(naked) void MasterOfFireFix() {
+    __asm
+    {
+        sub eax, 1
+        and ebx, eax
+        test ebx, ebx
+        je DEFENSE_IS_ZERO
+        mov ecx, esi
+        mov edx, [esi]
+        push 0xCA 
+        mov ecx, esi
+        call dword ptr[edx + 0x28]
+        test eax, eax
+        je FIRE_EFFECT_NOT_PRESENT
+        mov edx, [esi]
+        push 0x55
+        mov ecx, esi
+        call dword ptr[edx + 0x28C]
+        test al, al
+        jne UNIT_IS_ARMOURED
+        shr ebx, 1
+        DEFENSE_IS_ZERO:
+    FIRE_EFFECT_NOT_PRESENT:
+    UNIT_IS_ARMOURED:
+        mov eax, ebx;
+        pop  edi
+            pop  esi
+            pop  ebp
+            pop  ebx
+            add esp, 8
+            ret
+    }
+}

--- a/OneStackSplit.cpp
+++ b/OneStackSplit.cpp
@@ -1,0 +1,7 @@
+#include "pch.h"
+// Stack splits distrubite 1 creature to the new stack instead of half of the original size
+
+void OneStackSplit_init(pugi::xml_document& doc) {
+    assembly_patches.push_back({ PATCH_WRTE, 0x007866A6, 6, nullptr, 0, 0, 0, "B801000000C3" });
+    assembly_patches.push_back({ PATCH_WRTE, 0x00786A3B, 8, nullptr, 0, 0, 0, "B801000000909090" });
+}

--- a/mainH5.cpp
+++ b/mainH5.cpp
@@ -14,6 +14,10 @@ void init_patches(pugi::xml_document& doc) {
     RuneOfTheDragonForm_init(doc);
     CombatAIFix_init(doc);
     AgilityFix_init(doc);
+    OneStackSplit_init(doc);
+    BookOfPowerLevelUp_init(doc);
+    MasterOfFireFix_init(doc);
+    EncourageFix_init(doc);
 }
 
 int main() {

--- a/mainH5.h
+++ b/mainH5.h
@@ -55,3 +55,7 @@ void SnareFix_init(pugi::xml_document& doc);
 void RuneOfTheDragonForm_init(pugi::xml_document& doc);
 void CombatAIFix_init(pugi::xml_document& doc);
 void AgilityFix_init(pugi::xml_document& doc);
+void OneStackSplit_init(pugi::xml_document& doc);
+void BookOfPowerLevelUp_init(pugi::xml_document& doc);
+void MasterOfFireFix_init(pugi::xml_document& doc);
+void EncourageFix_init(pugi::xml_document& doc);


### PR DESCRIPTION
Introducing the following changes:
- change: Stack splits distrubite 1 creature to the new stack instead of half of the original size
- fix: After level up hero max mana calculation does not take into account knowledge bonus from book of power.
- fix: Master of Fire always substracting half defense from the moment of impact instead of half of the current creature defense
- fix: Encourage affected by resistance
